### PR TITLE
Add new compass: Eurekan Elementals

### DIFF
--- a/src/Compasses/Configs/EurekanCompassConfig.cs
+++ b/src/Compasses/Configs/EurekanCompassConfig.cs
@@ -1,0 +1,6 @@
+﻿namespace AetherCompass.Compasses.Configs
+{
+    [Serializable]
+    public class EurekanCompassConfig : CompassConfig
+    { }
+}

--- a/src/Compasses/EurekanCompass.cs
+++ b/src/Compasses/EurekanCompass.cs
@@ -1,0 +1,69 @@
+﻿using AetherCompass.Common;
+using AetherCompass.Common.Attributes;
+using AetherCompass.Compasses.Objectives;
+using AetherCompass.Game;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using ImGuiNET;
+
+
+namespace AetherCompass.Compasses
+{
+    [CompassType(CompassType.Standard)]
+    public class EurekanCompass : Compass
+    {
+        public override string CompassName => "Eurekan Compass";
+        public override string Description => "Detecting nearby Eurekan Elementals.";
+
+        private protected override CompassConfig CompassConfig => Plugin.Config.EurekanConfig;
+
+        private static System.Numerics.Vector4 infoTextColour = new(.8f, .95f, .75f, 1);
+        private const float infoTextShadowLightness = .1f;
+
+        private const uint elementalMarkerIconId = 15835;
+
+        public override bool IsEnabledInCurrentTerritory()
+            => ZoneWatcher.CurrentTerritoryType?.TerritoryIntendedUse == 41;
+
+
+        private protected override unsafe string GetClosestObjectiveDescription(CachedCompassObjective _)
+            => "Elemental";
+
+        public override unsafe bool IsObjective(GameObject* o) => o != null && (o->ObjectKind == (byte)ObjectKind.BattleNpc
+            ) && (IsEurekanElementalName(CompassUtil.GetName(o)));
+
+        public override unsafe DrawAction? CreateDrawDetailsAction(CachedCompassObjective objective)
+        {
+            if (objective.IsEmpty()) return null;
+            return new(() =>
+            {
+                ImGui.Text($"{objective.Name}");
+                ImGui.BulletText($"{CompassUtil.MapCoordToFormattedString(objective.CurrentMapCoord)} (approx.)");
+                ImGui.BulletText($"{objective.CompassDirectionFromPlayer},  " +
+                    $"{CompassUtil.DistanceToDescriptiveString(objective.Distance3D, false)}");
+                ImGui.BulletText(CompassUtil.AltitudeDiffToDescriptiveString(objective.AltitudeDiff));
+                DrawFlagButton($"{(long)objective.GameObject}", objective.CurrentMapCoord);
+                ImGui.Separator();
+            });
+        }
+
+        public override unsafe DrawAction? CreateMarkScreenAction(CachedCompassObjective objective)
+        {
+            if (objective.IsEmpty()) return null;
+            return GenerateDefaultScreenMarkerDrawAction(objective,
+                elementalMarkerIconId, new System.Numerics.Vector2(24,32), .9f,
+                $"{objective.Name}, {CompassUtil.DistanceToDescriptiveString(objective.Distance3D, true)}",
+                infoTextColour, infoTextShadowLightness, out _, important: objective.Distance3D < 60);
+        }
+
+        private static bool IsEurekanElementalName(string? name)
+        {
+            if (name == null) return false;
+            name = name.ToLower();
+            return name == "hydatos elemental" || name == "pyros elemental" || name == "pagos elemental" || name == "anemos elemental"
+                || name == "ヒュダトス・エレメンタル" ||  name == "パゴス・エレメンタル" || name == "ピューロス・エレメンタル" || name == "アネモス・エレメンタル"
+                || name == "élémentaire hydatos" || name == "élémentaire pyros" || name == "élémentaire pagos" || name == "élémentaire anemos"
+                || name == "hydatos-elementar" || name == "pyros-elementar" || name == "pagos-elementar" || name == "anemos-elementar"
+                ;
+        }
+    }
+}

--- a/src/PluginConfig.cs
+++ b/src/PluginConfig.cs
@@ -47,6 +47,7 @@ namespace AetherCompass
         public GatheringPointCompassConfig GatheringConfig { get; private set; } = new();
         public IslandSanctuaryCompassConfig IslandConfig { get; private set; } = new();
         public QuestCompassConfig QuestConfig { get; private set; } = new();
+        public EurekanCompassConfig EurekanConfig { get; private set; } = new();
 
 #if DEBUG
         [JsonIgnore]
@@ -109,6 +110,7 @@ namespace AetherCompass
             GatheringConfig.Load(config.GatheringConfig);
             IslandConfig.Load(config.IslandConfig);
             QuestConfig.Load(config.QuestConfig);
+            EurekanConfig.Load(config.EurekanConfig);
         }
 
         public void Save()


### PR DESCRIPTION
Compass to facilitate finding elementals inside of Eureka, especially when in a hurry to prepare for Baldesion Arsenal.
Implementation might be a bit sloppy, first time working with Dalamud. Not entirely sure if `TerritoryIntendedUse == 41` is exclusive to Eureka or is shared with other instances.